### PR TITLE
Malloc Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can use macro `MALLOC` and `FREE` defined in the header to malloc and free l
 A destructor attribute is set to `free_g_garbage_lst(void)` to destroy our chained list at the end of the programm execution. With this ability, you can leave a programm with `exit` and each allocated element is gonna be free properly.
 
 ### Exemple 1
-```
+```c
 #include "garbage.h"
 #include <string.h>
 #include <stdio.h>
@@ -26,7 +26,7 @@ int		main(int argc, char **argv)
 ```
 
 ### Exemple 2
-```
+```c
 #include "garbage.h"
 #include <string.h>
 #include <stdio.h>

--- a/garbage.h
+++ b/garbage.h
@@ -38,7 +38,7 @@ struct		s_garblst
 extern t_garblst	*g_garbage;
 
 void		garbage_free(void *ptr);
-void		*garbage_malloc(int size);
+void		*garbage_malloc(size_t size);
 void		free_g_garbage_lst(void) __attribute__((destructor));
 
 #endif

--- a/garbage_alloc.c
+++ b/garbage_alloc.c
@@ -70,7 +70,7 @@ void		garbage_free(void *ptr)
 ** Store the new allocated pointer in the g_garbage list.
 */
 
-void		*garbage_malloc(int size)
+void		*garbage_malloc(size_t size)
 {
 	t_garblst	*garb_item;
 


### PR DESCRIPTION
Replaced `int` by `size_t` in the allocator function. Could crash if you pass a negative number as size.